### PR TITLE
add static first mandatory field builder factory method to generated classes

### DIFF
--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/BuilderWriter.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/BuilderWriter.java
@@ -247,8 +247,8 @@ public class BuilderWriter {
             previousWasMandatory = f.mandatory();
             out.flush();
         }
-        out.println();
         if (firstFieldStaticMethod.isPresent() && !firstFieldStaticMethod.get().isEmpty()) {
+            out.println();
             out.print(firstFieldStaticMethod.get());
         }
     }

--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/BuilderWriter.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/BuilderWriter.java
@@ -214,11 +214,11 @@ public class BuilderWriter {
             if (!firstFieldStaticMethod.isPresent()) {
                 // only do this if field is mandatory
                 if (f.mandatory()) {
-                Indent indent = out.indent().copy().left();
-                String s = String.format("%spublic static %s %s(%s %s) {\n", indent, nextBuilderName, f.fieldName, baseImportedType(f, out.imports()),
-                        f.fieldName) //
-                        + String.format("%sreturn builder().%s(%s);\n", indent.right(), f.fieldName, f.fieldName) //
-                        + String.format("%s}\n", indent.left());
+                    Indent indent = out.indent().copy().left();
+                    String s = String.format("%spublic static %s %s(%s %s) {\n", indent, nextBuilderName, f.fieldName,
+                            baseImportedType(f, out.imports()), f.fieldName) //
+                            + String.format("%sreturn builder().%s(%s);\n", indent.right(), f.fieldName, f.fieldName) //
+                            + String.format("%s}\n", indent.left());
                     firstFieldStaticMethod = Optional.of(s);
                 } else {
                     firstFieldStaticMethod = Optional.of("");

--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/BuilderWriter.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/BuilderWriter.java
@@ -11,6 +11,7 @@ import org.davidmoten.oa3.codegen.generator.Generator.MapType;
 import org.davidmoten.oa3.codegen.generator.Names;
 import org.davidmoten.oa3.codegen.generator.internal.CodePrintWriter;
 import org.davidmoten.oa3.codegen.generator.internal.Imports;
+import org.davidmoten.oa3.codegen.generator.internal.Indent;
 import org.davidmoten.oa3.codegen.generator.internal.Util;
 import org.davidmoten.oa3.codegen.runtime.MapBuilder;
 import org.davidmoten.oa3.codegen.runtime.Preconditions;
@@ -72,6 +73,7 @@ public class BuilderWriter {
         boolean previousWasMandatory = true;
         boolean inFirstBuilder = true;
         Field last = sortedFields.get(sortedFields.size() - 1);
+        Optional<String> firstFieldStaticMethod = Optional.empty();
         for (Field f : sortedFields) {
             final String nextBuilderName;
             if (f.mandatory()) {
@@ -209,6 +211,19 @@ public class BuilderWriter {
                     writeBuildMethod(out, fields, importedBuiltType, builderField);
                 }
             }
+            if (!firstFieldStaticMethod.isPresent()) {
+                // only do this if field is mandatory
+                if (f.mandatory()) {
+                Indent indent = out.indent().copy().left();
+                String s = String.format("%spublic static %s %s(%s %s) {\n", indent, nextBuilderName, f.fieldName, baseImportedType(f, out.imports()),
+                        f.fieldName) //
+                        + String.format("%sreturn builder().%s(%s);\n", indent.right(), f.fieldName, f.fieldName) //
+                        + String.format("%s}\n", indent.left());
+                    firstFieldStaticMethod = Optional.of(s);
+                } else {
+                    firstFieldStaticMethod = Optional.of("");
+                }
+            }
             if (f.mapType.isPresent() && f == last) {
                 writeBuildMethod(out, fields, importedBuiltType, builderField);
             }
@@ -232,7 +247,10 @@ public class BuilderWriter {
             previousWasMandatory = f.mandatory();
             out.flush();
         }
-
+        out.println();
+        if (firstFieldStaticMethod.isPresent() && !firstFieldStaticMethod.get().isEmpty()) {
+            out.print(firstFieldStaticMethod.get());
+        }
     }
 
     private static void writeSingleValueStaticFactoryMethods(CodePrintWriter out, Field field, String importedBuiltType) {

--- a/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/main/SchemasTest.java
+++ b/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/main/SchemasTest.java
@@ -913,7 +913,7 @@ public class SchemasTest {
         map1.put("hello", "there");
         Map<String, Object> map2 = new HashMap<>();
         map2.put("buy", "nothing");
-        TwoMaps a = TwoMaps.stuff(Optional.of(map1)).other(Optional.of(map2)).build();
+        TwoMaps a = TwoMaps.builder().stuff(Optional.of(map1)).other(Optional.of(map2)).build();
         String json = m.writeValueAsString(a);
         TwoMaps b = m.readValue(json, TwoMaps.class);
         assertEquals(map1, b.stuff().get());
@@ -1083,7 +1083,7 @@ public class SchemasTest {
     public void testMixRequiredNotRequired() throws JsonProcessingException {
         MixRequiredAndNotRequiredWithConstraint a = MixRequiredAndNotRequiredWithConstraint.a("hello").build();
         String json = m.writeValueAsString(a);
-        MixRequiredAndNotRequiredWithConstraint b = m.readValue(json, MixRequiredAndNotRequiredWithConstraint.class);
+        m.readValue(json, MixRequiredAndNotRequiredWithConstraint.class);
     }
 
     private static void onePublicConstructor(Class<?> c) {

--- a/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/main/SchemasTest.java
+++ b/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/main/SchemasTest.java
@@ -680,7 +680,7 @@ public class SchemasTest {
         Dog a = m.readValue(json, Dog.class);
         assertEquals("brown and curly", a.pet().description());
         assertEquals(Breed.CROSS, a.object1().breed().get());
-        Dog b = Dog.builder() //
+        Dog b = Dog
                 .pet(Pet.description("brown and curly")) //
                 .object1(Dog.Object1.breed(Breed.CROSS)) //
                 .build();
@@ -693,7 +693,7 @@ public class SchemasTest {
         Dog2 a = m.readValue(json, Dog2.class);
         assertEquals("brown and curly", a.pet().description());
         assertEquals(DogBreed.CROSS, a.breeding().breed());
-        Dog2 b = Dog2.builder() //
+        Dog2 b = Dog2 //
                 .pet(Pet.description("brown and curly")) //
                 .breeding(Breeding.builder() //
                         .breeder("Jane's Kennels") //
@@ -752,13 +752,13 @@ public class SchemasTest {
     public void testMsi() throws JsonProcessingException {
         Circle circle = new Circle(new Latitude(25.1F), new Longitude(-33.1F), 1);
         MetBroadcastArea mbca = MetBroadcastArea.of(Geometry.of(circle));
-        MetBroadcast mbc = MetBroadcast.builder().area(mbca).priority(NonSARPriority.SAFETY).build();
+        MetBroadcast mbc = MetBroadcast.area(mbca).priority(NonSARPriority.SAFETY).build();
         Broadcast broadcast = Broadcast.of(mbc);
         OffsetDateTime createdTime = OffsetDateTime.parse("2023-04-05T12:15:26.025+10:00");
         OffsetDateTime startTime = OffsetDateTime.parse("2023-04-05T14:15:26.025+10:00");
         OffsetDateTime endTime = OffsetDateTime.parse("2023-04-06T12:00:26.025+10:00");
         MsiId msiId = new MsiId("8ds9f8sd98-dsfds8989");
-        Msi msi = Msi.builder() //
+        Msi msi = Msi //
                 .id(msiId) //
                 .broadcast(broadcast) //
                 .createdTime(createdTime) //
@@ -821,7 +821,7 @@ public class SchemasTest {
         assertEquals(1L, b.properties().get("hello"));
         assertEquals(23L, b.properties().get("there"));
         @SuppressWarnings("unused")
-        Geometry g = Geometry.of(Circle.builder() //
+        Geometry g = Geometry.of(Circle //
                 .lat(Latitude.value(-35f)) //
                 .lon(Longitude.value(142f)) //
                 .radiusNm(20) //
@@ -830,7 +830,7 @@ public class SchemasTest {
 
     @Test
     public void testAdditionalPropertiesTrue() throws JsonProcessingException {
-        Circle c = Circle.builder().lat(Latitude.value(11f)).lon(Longitude.value(123f)).radiusNm(123).build();
+        Circle c = Circle.lat(Latitude.value(11f)).lon(Longitude.value(123f)).radiusNm(123).build();
         AdditionalPropertiesTrue a = AdditionalPropertiesTrue.builder() //
                 .addToProperties("hello", 1L) //
                 .add("there", c) //
@@ -900,7 +900,7 @@ public class SchemasTest {
     @Test
     public void testAnyObjectProperty2() throws JsonProcessingException {
         // use of {} type translates to a Map (normally a LinkedHashMap)
-        AnyObjectProperty2 a = AnyObjectProperty2.builder().stuff(Collections.emptyMap()).other("abc").build();
+        AnyObjectProperty2 a = AnyObjectProperty2.stuff(Collections.emptyMap()).other("abc").build();
         String json = m.writeValueAsString(a);
         AnyObjectProperty2 b = m.readValue(json, AnyObjectProperty2.class);
         assertTrue(b.stuff().isEmpty());
@@ -913,7 +913,7 @@ public class SchemasTest {
         map1.put("hello", "there");
         Map<String, Object> map2 = new HashMap<>();
         map2.put("buy", "nothing");
-        TwoMaps a = TwoMaps.builder().stuff(Optional.of(map1)).other(Optional.of(map2)).build();
+        TwoMaps a = TwoMaps.stuff(Optional.of(map1)).other(Optional.of(map2)).build();
         String json = m.writeValueAsString(a);
         TwoMaps b = m.readValue(json, TwoMaps.class);
         assertEquals(map1, b.stuff().get());
@@ -958,7 +958,7 @@ public class SchemasTest {
 
     @Test
     public void testNullable() throws JsonProcessingException {
-        NullableExample a = NullableExample.builder().a(123).b(B.HELLO).notReq(JsonNullable.of(null)).build();
+        NullableExample a = NullableExample.a(123).b(B.HELLO).notReq(JsonNullable.of(null)).build();
         String json = m.writeValueAsString(a);
         assertTrue(json.contains("\"req\":null"));
         assertTrue(json.contains("\"notReq\":null"));
@@ -1081,7 +1081,7 @@ public class SchemasTest {
     
     @Test
     public void testMixRequiredNotRequired() throws JsonProcessingException {
-        MixRequiredAndNotRequiredWithConstraint a = MixRequiredAndNotRequiredWithConstraint.builder().a("hello").build();
+        MixRequiredAndNotRequiredWithConstraint a = MixRequiredAndNotRequiredWithConstraint.a("hello").build();
         String json = m.writeValueAsString(a);
         MixRequiredAndNotRequiredWithConstraint b = m.readValue(json, MixRequiredAndNotRequiredWithConstraint.class);
     }


### PR DESCRIPTION
Provides a shortcut for builder use. For example you can omit the first `.builder()` call:

```java
Circle circle = Circle
    .latitude(Latitude.value(-10))
    .longitude(Longitude.value(140))
    .radiusNm(200)
    .build();
```
or, as was available previously: 

```java
Circle circle = Circle
    .builder()
    .latitude(Latitude.value(-10))
    .longitude(Longitude.value(140))
    .radiusNm(200)
    .build();
```