### PR TITLE
Octet stream fix

### DIFF
--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/ClientServerGenerator.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/ClientServerGenerator.java
@@ -20,7 +20,6 @@ import org.davidmoten.oa3.codegen.generator.internal.Util;
 import org.davidmoten.oa3.codegen.generator.writer.ClientCodeWriter;
 import org.davidmoten.oa3.codegen.generator.writer.ServerCodeWriterSpringBoot;
 import org.davidmoten.oa3.codegen.util.ImmutableList;
-import org.springframework.core.io.Resource;
 
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
@@ -212,7 +211,7 @@ public class ClientServerGenerator {
                 } else {
                     // loop through all mime-types and pick first non-default to infer return class
                     // name
-                    final String defaultReturnClassFullName = Resource.class.getCanonicalName();
+                    final String defaultReturnClassFullName = byte[].class.getCanonicalName();
                     returnFullClassName = content. //
                             keySet() //
                             .stream() //

--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/ServerCodeWriterSpringBoot.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/ServerCodeWriterSpringBoot.java
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -204,7 +205,13 @@ public final class ServerCodeWriterSpringBoot {
             } else if (!m.returnFullClassName.isPresent()) {
                 importedReturnType = "void";
             } else {
-                importedReturnType = out.add(m.returnFullClassName.get());
+                final String fullClassName;
+                if (m.returnFullClassName.orElse("").equals(byte[].class.getCanonicalName())) {
+                    fullClassName = Resource.class.getCanonicalName();
+                } else {
+                    fullClassName = m.returnFullClassName.get();
+                }
+                importedReturnType = out.add(fullClassName);
             }
 //            @RequestMapping(
 //                    method = RequestMethod.POST,

--- a/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/DefaultSerializer.java
+++ b/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/DefaultSerializer.java
@@ -55,7 +55,7 @@ public class DefaultSerializer implements Serializer {
                 try (InputStream is = in) {
                     return (T) new String(Util.read(is), StandardCharsets.UTF_8);
                 }
-            } else if (cls.equals(byte[].class) && MediaType.isOctetStream(contentType)) {
+            } else if (MediaType.isOctetStream(contentType)) {
                 try (InputStream is = in) {
                     return (T) Util.read(is);
                 }

--- a/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/Http.java
+++ b/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/Http.java
@@ -114,11 +114,15 @@ public final class Http {
         }
 
         public Builder acceptApplicationJson() {
-            return header("Accept", "application/json");
+            return accept("application/json");
         }
 
         public Builder acceptAny() {
-            return header("Accept", "*/*");
+            return accept("*/*");
+        }
+        
+        public Builder accept(String mediaType) {
+            return header("Accept", mediaType);
         }
 
         public Builder param(String name, Optional<?> value, ParameterType type, Optional<String> contentType) {

--- a/openapi-codegen-maven-plugin-test/src/test/resources/application.properties
+++ b/openapi-codegen-maven-plugin-test/src/test/resources/application.properties
@@ -1,2 +1,2 @@
-logging.level.org.springframework=DEBUG
-logging.level.root=DEBUG
+logging.level.org.springframework=OFF
+logging.level.root=OFF

--- a/openapi-codegen-maven-plugin-test/src/test/resources/application.properties
+++ b/openapi-codegen-maven-plugin-test/src/test/resources/application.properties
@@ -1,2 +1,2 @@
-logging.level.org.springframework=OFF
-logging.level.root=OFF
+logging.level.org.springframework=DEBUG
+logging.level.root=DEBUG


### PR DESCRIPTION
A response of content-type application/pdf of type: string, format: binary was not retrievable on the client side and the client was using a Resource type from Spring which we don't want in the client. Shifted to byte[] on the client (can use streams later).