### PR TITLE
Add per-call request builder

### DIFF
--- a/openapi-codegen-example-pet-store/src/test/java/pet/store/test/PetStoreServerTest.java
+++ b/openapi-codegen-example-pet-store/src/test/java/pet/store/test/PetStoreServerTest.java
@@ -30,7 +30,7 @@ public class PetStoreServerTest {
 
     @Test
     public void testFindPets() {
-        FindPets200Response r = client().findPets(Optional.empty(), 10);
+        FindPets200Response r = client().findPets(Optional.empty(), 10).get();
         assertEquals(1, r.value().size());
         assertEquals("fido", r.value().get(0).name());
     }

--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/ClientCodeWriter.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/ClientCodeWriter.java
@@ -14,7 +14,7 @@ import org.davidmoten.oa3.codegen.generator.ParamType;
 import org.davidmoten.oa3.codegen.generator.internal.CodePrintWriter;
 import org.davidmoten.oa3.codegen.generator.internal.WriterUtil;
 import org.davidmoten.oa3.codegen.http.Http;
-import org.davidmoten.oa3.codegen.http.Http.CallBuilder;
+import org.davidmoten.oa3.codegen.http.Http.RequestBuilder;
 import org.davidmoten.oa3.codegen.http.HttpMethod;
 import org.davidmoten.oa3.codegen.http.Interceptor;
 import org.davidmoten.oa3.codegen.http.MediaType;
@@ -122,7 +122,7 @@ public class ClientCodeWriter {
 //            }
             ServerCodeWriterSpringBoot.writeMethodJavadoc(out, m,
                     Optional.of("call builder"), Maps.empty());
-            out.line("public %s<%s> %s(%s) {", CallBuilder.class, importedReturnType, m.methodName, params);
+            out.line("public %s<%s> %s(%s) {", RequestBuilder.class, importedReturnType, m.methodName, params);
             out.line("return %s", Http.class);
             out.right().right();
             out.line(".method(%s.%s)", HttpMethod.class, m.httpMethod.name());

--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/ClientCodeWriter.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/ClientCodeWriter.java
@@ -72,8 +72,6 @@ public class ClientCodeWriter {
         out.closeParen();
     }
 
-    private static final String FULL_RESPONSE_SUFFIX = "FullResponse";
-
     private static void writeClientClassMethods(CodePrintWriter out, List<Method> methods) {
         methods.forEach(m -> {
             out.right().right();

--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/ClientCodeWriter.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/ClientCodeWriter.java
@@ -166,10 +166,10 @@ public class ClientCodeWriter {
                 out.line(".whenContentTypeMatches(\"%s\")", r.mediaType());
             });
 			if (hasPrimaryResponse) {
-				out.line(".<%s>callBuilder(\"%s\", \"%s\");", importedReturnType, m.primaryStatusCode.get(),
+				out.line(".<%s>requestBuilder(\"%s\", \"%s\");", importedReturnType, m.primaryStatusCode.get(),
 						m.primaryMediaType.get());
 			} else {
-				out.line(".<%s>callBuilder();", importedReturnType);
+				out.line(".<%s>requestBuilder();", importedReturnType);
 			}
             out.left().left();
             out.closeParen();

--- a/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/Http.java
+++ b/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/Http.java
@@ -192,8 +192,12 @@ public final class Http {
         }
 
         public HttpResponse call() {
-            HttpResponse r = Http.call(httpService, method, basePath, path, serializer, interceptors, headers, values, responseDescriptors,
+        	return Http.call(httpService, method, basePath, path, serializer, interceptors, headers, values, responseDescriptors,
                     allowPatch);
+        }
+        
+        public HttpResponse callAssertIsPrimaryResponse() {
+            HttpResponse r = call();
             if (assertStatusCodeMatches.isPresent()) {
             	r.assertStatusCodeMatches(assertStatusCodeMatches.get());
             }
@@ -253,7 +257,7 @@ public final class Http {
         }
         
         public T get() {
-        	return fullResponse().dataUnwrapped();
+        	return builder.callAssertIsPrimaryResponse().dataUnwrapped();
         }
     }
 

--- a/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/Http.java
+++ b/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/Http.java
@@ -44,7 +44,10 @@ import com.github.davidmoten.guavamini.annotations.VisibleForTesting;
 
 public final class Http {
 
-    private static Logger log = LoggerFactory.getLogger(Http.class);
+	private static Logger log = LoggerFactory.getLogger(Http.class);
+
+	private static final long DEFAULT_CONNECT_TIMEOUT_MS = 30000L;
+    private static final long DEFAULT_READ_TIMEOUT_MS = 180000L;
 
     public static Builder method(HttpMethod method) {
         return new Builder(method);
@@ -64,6 +67,8 @@ public final class Http {
         private HttpService httpService = DefaultHttpService.INSTANCE;
 		private Optional<String> assertStatusCodeMatches = Optional.empty();
 		private Optional<String> assertContentTypeMatches = Optional.empty();
+		public Optional<Long> connectTimeoutMs = Optional.empty();
+		public Optional<Long> readTimeoutMs = Optional.empty();
 
         Builder(HttpMethod method) {
             this.method = method;
@@ -95,6 +100,20 @@ public final class Http {
             } else {
                 return this;
             }
+        }
+        
+        public Builder connectTimeout(long duration, TimeUnit unit) {
+        	Preconditions.checkArgumentNotNull(duration, "duration");
+        	Preconditions.checkArgumentNotNull(unit, "unit");
+        	this.connectTimeoutMs = Optional.of(unit.toMillis(duration));
+        	return this;
+        }
+        
+        public Builder readTimeout(long duration, TimeUnit unit) {
+        	Preconditions.checkArgumentNotNull(duration, "duration");
+        	Preconditions.checkArgumentNotNull(unit, "unit");
+        	this.readTimeoutMs = Optional.of(unit.toMillis(duration));
+        	return this;
         }
 
         public Builder allowPatch() {
@@ -193,7 +212,7 @@ public final class Http {
 
         public HttpResponse call() {
         	return Http.call(httpService, method, basePath, path, serializer, interceptors, headers, values, responseDescriptors,
-                    allowPatch);
+                    allowPatch, connectTimeoutMs, readTimeoutMs);
         }
         
         public HttpResponse callAssertIsPrimaryResponse() {
@@ -243,12 +262,12 @@ public final class Http {
         }
         
         public CallBuilder<T> connectTimeout(long duration, TimeUnit unit) {
-        	// TODO
+        	builder.connectTimeout(duration, unit);
         	return this;
         }
         
         public CallBuilder<T> readTimeout(long duration, TimeUnit unit) {
-        	// TODO
+        	builder.readTimeout(duration, unit);
         	return this;
         }
         
@@ -365,9 +384,9 @@ public final class Http {
             Headers requestHeaders, //
             List<ParameterValue> parameters, //
             // (statusCode, contentType, class)
-            List<ResponseDescriptor> descriptors, boolean allowPatch) {
+            List<ResponseDescriptor> descriptors, boolean allowPatch, Optional<Long> connectTimeoutMs, Optional<Long> readTimeoutMs) {
         return call(httpService, method, basePath, pathTemplate, serializer, interceptors, requestHeaders, parameters,
-                (statusCode, contentType) -> match(descriptors, statusCode, contentType), allowPatch);
+                (statusCode, contentType) -> match(descriptors, statusCode, contentType), allowPatch, connectTimeoutMs, readTimeoutMs);
     }
 
     private static Optional<Class<?>> match(List<ResponseDescriptor> descriptors, Integer statusCode,
@@ -392,7 +411,8 @@ public final class Http {
             Headers requestHeaders, //
             List<ParameterValue> parameters, //
             // (statusCode x contentType) -> class
-            BiFunction<? super Integer, ? super String, Optional<Class<?>>> responseCls, boolean allowPatch) {
+            BiFunction<? super Integer, ? super String, Optional<Class<?>>> responseCls, boolean allowPatch,
+            		Optional<Long> connectTimeoutMs, Optional<Long> readTimeoutMs) {
         String url = buildUrl(basePath, pathTemplate, parameters);
         Optional<ParameterValue> requestBody = parameters.stream().filter(x -> x.type() == ParameterType.BODY)
                 .findFirst();
@@ -412,7 +432,7 @@ public final class Http {
             }
             log.debug("connecting to method=" + r.method() + ", url=" + url + ", headers=" + r.headers());
             return connectAndProcess(serializer, parameters, responseCls, r.url(), requestBody, r.headers(), r.method(),
-                    httpService, options);
+                    httpService, connectTimeoutMs, readTimeoutMs, options);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -421,10 +441,13 @@ public final class Http {
     private static HttpResponse connectAndProcess(Serializer serializer, List<ParameterValue> parameters,
             BiFunction<? super Integer, ? super String, Optional<Class<?>>> responseCls, String url,
             Optional<ParameterValue> requestBody, Headers headers, final HttpMethod method, HttpService httpService,
+            Optional<Long> connectTimeoutMs, Optional<Long> readTimeoutMs,
             Option... options)
             throws IOException, MalformedURLException, ProtocolException, StreamReadException, DatabindException {
         log.debug("Http.headers={}", headers);
         HttpConnection con = httpService.connection(url, method, options);
+        con.setConnectTimeoutMs(connectTimeoutMs.orElse(DEFAULT_CONNECT_TIMEOUT_MS));
+        con.setReadTimeoutMs(readTimeoutMs.orElse(DEFAULT_READ_TIMEOUT_MS));
         parameters.stream() //
                 .filter(p -> p.type() == ParameterType.HEADER && p.value().isPresent()) //
                 .forEach(p -> headers.put(p.name(), String.valueOf(p.value().get())));

--- a/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/Http.java
+++ b/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/Http.java
@@ -198,16 +198,16 @@ public final class Http {
             return new BuilderWithReponseDescriptor(this, cls);
         }
         
-        public <T> CallBuilder<T> callBuilder() {
-        	return new CallBuilder<>(this);
+        public <T> RequestBuilder<T> callBuilder() {
+        	return new RequestBuilder<>(this);
         }
         
-        public <T> CallBuilder<T> callBuilder(String primaryStatusCode, String primaryMediaType) {
+        public <T> RequestBuilder<T> callBuilder(String primaryStatusCode, String primaryMediaType) {
         	Preconditions.checkArgumentNotNull(primaryStatusCode);
         	Preconditions.checkArgumentNotNull(primaryMediaType);
         	this.assertStatusCodeMatches = Optional.of(primaryStatusCode);
             this.assertContentTypeMatches = Optional.of(primaryMediaType);
-        	return new CallBuilder<T>(this);
+        	return new RequestBuilder<T>(this);
         }
 
         public HttpResponse call() {
@@ -228,45 +228,45 @@ public final class Http {
 
     }
     
-    public static final class CallBuilder<T> {
+    public static final class RequestBuilder<T> {
 
 		private Builder builder;
 
-		public CallBuilder(Builder builder) {
+		public RequestBuilder(Builder builder) {
 			this.builder = builder;
 		}
     	
-		public CallBuilder<T> acceptApplicationJson() {
+		public RequestBuilder<T> acceptApplicationJson() {
             builder.accept("application/json");
             return this;
         }
 
-        public CallBuilder<T> acceptAny() {
+        public RequestBuilder<T> acceptAny() {
             builder.accept("*/*");
             return this;
         }
         
-        public CallBuilder<T> accept(String mediaType) {
+        public RequestBuilder<T> accept(String mediaType) {
             builder.header("Accept", mediaType);
             return this;
         }
         
-        public CallBuilder<T> header(String name, String value) {
+        public RequestBuilder<T> header(String name, String value) {
             builder.header(name, value);
             return this;
         }
         
-        public CallBuilder<T> interceptor(Interceptor interceptor) {
+        public RequestBuilder<T> interceptor(Interceptor interceptor) {
         	builder.interceptor(interceptor);
         	return this;
         }
         
-        public CallBuilder<T> connectTimeout(long duration, TimeUnit unit) {
+        public RequestBuilder<T> connectTimeout(long duration, TimeUnit unit) {
         	builder.connectTimeout(duration, unit);
         	return this;
         }
         
-        public CallBuilder<T> readTimeout(long duration, TimeUnit unit) {
+        public RequestBuilder<T> readTimeout(long duration, TimeUnit unit) {
         	builder.readTimeout(duration, unit);
         	return this;
         }

--- a/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/Http.java
+++ b/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/Http.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -175,12 +176,68 @@ public final class Http {
         public BuilderWithReponseDescriptor responseAs(Class<?> cls) {
             return new BuilderWithReponseDescriptor(this, cls);
         }
+        
+        public <T> CallBuilder<T> callBuilder(Class<?> primaryResponseCls) {
+        	return new CallBuilder<>(this);
+        }
 
         public HttpResponse call() {
             return Http.call(httpService, method, basePath, path, serializer, interceptors, headers, values, responseDescriptors,
                     allowPatch);
         }
 
+    }
+    
+    public static final class CallBuilder<T> {
+
+		private Builder builder;
+
+		public CallBuilder(Builder builder) {
+			this.builder = builder;
+		}
+    	
+		public CallBuilder<T> acceptApplicationJson() {
+            builder.accept("application/json");
+            return this;
+        }
+
+        public CallBuilder<T> acceptAny() {
+            builder.accept("*/*");
+            return this;
+        }
+        
+        public CallBuilder<T> accept(String mediaType) {
+            builder.header("Accept", mediaType);
+            return this;
+        }
+        
+        public CallBuilder<T> header(String name, String value) {
+            builder.header(name, value);
+            return this;
+        }
+        
+        public CallBuilder<T> interceptor(Interceptor interceptor) {
+        	builder.interceptor(interceptor);
+        	return this;
+        }
+        
+        public CallBuilder<T> connectTimeout(long duration, TimeUnit unit) {
+        	// TODO
+        	return this;
+        }
+        
+        public CallBuilder<T> readTimeout(long duration, TimeUnit unit) {
+        	// TODO
+        	return this;
+        }
+        
+        public HttpResponse fullResponse() {
+        	return builder.call();
+        }
+        
+        public T call() {
+        	return fullResponse().dataUnwrapped();
+        }
     }
 
     public static final class BuilderWithBasePath {

--- a/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/Http.java
+++ b/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/Http.java
@@ -198,11 +198,11 @@ public final class Http {
             return new BuilderWithReponseDescriptor(this, cls);
         }
         
-        public <T> RequestBuilder<T> callBuilder() {
+        public <T> RequestBuilder<T> requestBuilder() {
         	return new RequestBuilder<>(this);
         }
         
-        public <T> RequestBuilder<T> callBuilder(String primaryStatusCode, String primaryMediaType) {
+        public <T> RequestBuilder<T> requestBuilder(String primaryStatusCode, String primaryMediaType) {
         	Preconditions.checkArgumentNotNull(primaryStatusCode);
         	Preconditions.checkArgumentNotNull(primaryMediaType);
         	this.assertStatusCodeMatches = Optional.of(primaryStatusCode);

--- a/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/service/HttpConnection.java
+++ b/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/service/HttpConnection.java
@@ -15,6 +15,10 @@ import java.util.function.Consumer;
 public interface HttpConnection {
 
     void header(String key, String value);
+    
+	void setConnectTimeoutMs(long connectTimeoutMs);
+	
+	void setReadTimeoutMs(long readTimeoutMs);
 
     /**
      * When a consumer is defined (when this method is called), this class is

--- a/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/service/internal/ApacheHttpClientHttpConnection.java
+++ b/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/service/internal/ApacheHttpClientHttpConnection.java
@@ -28,8 +28,8 @@ import org.davidmoten.oa3.codegen.util.Util;
 public class ApacheHttpClientHttpConnection implements HttpConnection {
 
     private final HttpUriRequestBase request;
-	private Optional<Long> connectTimeoutMs;
-	private Optional<Long> readTimeoutMs;
+	private Optional<Long> connectTimeoutMs = Optional.empty();
+	private Optional<Long> readTimeoutMs = Optional.empty();
 
     public ApacheHttpClientHttpConnection(HttpUriRequestBase request) {
         this.request = request;

--- a/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/service/internal/ApacheHttpClientHttpConnection.java
+++ b/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/service/internal/ApacheHttpClientHttpConnection.java
@@ -9,9 +9,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.config.RequestConfig.Builder;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ContentType;
@@ -25,6 +28,8 @@ import org.davidmoten.oa3.codegen.util.Util;
 public class ApacheHttpClientHttpConnection implements HttpConnection {
 
     private final HttpUriRequestBase request;
+	private Optional<Long> connectTimeoutMs;
+	private Optional<Long> readTimeoutMs;
 
     public ApacheHttpClientHttpConnection(HttpUriRequestBase request) {
         this.request = request;
@@ -34,6 +39,16 @@ public class ApacheHttpClientHttpConnection implements HttpConnection {
     public void header(String key, String value) {
         request.addHeader(key, value);
     }
+    
+	@Override
+	public void setConnectTimeoutMs(long connectTimeoutMs) {
+		this.connectTimeoutMs = Optional.of(connectTimeoutMs);
+	}
+
+	@Override
+	public void setReadTimeoutMs(long readTimeoutMs) {
+		this.readTimeoutMs = Optional.of(readTimeoutMs);
+	}
 
     @Override
     public void output(Consumer<? super OutputStream> consumer, String contentType, Optional<String> contentEncoding,
@@ -47,7 +62,11 @@ public class ApacheHttpClientHttpConnection implements HttpConnection {
 
     @Override
     public Response response() throws IOException {
-        try (CloseableHttpClient client = HttpClients.createDefault()) {
+    	Builder b = RequestConfig.custom();
+    	connectTimeoutMs.ifPresent(timeoutMs -> b.setConnectionRequestTimeout(0, TimeUnit.MILLISECONDS));
+    	readTimeoutMs.ifPresent(timeoutMs -> b.setResponseTimeout(timeoutMs, TimeUnit.MILLISECONDS));
+    	RequestConfig config = b.build();
+        try (CloseableHttpClient client = HttpClients.custom().setDefaultRequestConfig(config).build()) {
             HttpClientResponseHandler<Response> handler = r -> {
                 final InputStream in;
                 if (r.getEntity() != null) {

--- a/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/service/internal/DefaultHttpConnection.java
+++ b/openapi-codegen-http/src/main/java/org/davidmoten/oa3/codegen/http/service/internal/DefaultHttpConnection.java
@@ -65,4 +65,14 @@ public final class DefaultHttpConnection implements HttpConnection {
         con.disconnect();
     }
 
+	@Override
+	public void setConnectTimeoutMs(long connectTimeoutMs) {
+		con.setConnectTimeout((int) connectTimeoutMs);
+	}
+
+	@Override
+	public void setReadTimeoutMs(long readTimeoutMs) {
+		con.setReadTimeout((int) readTimeoutMs);
+	}
+
 }

--- a/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/library/LibraryServerTest.java
+++ b/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/library/LibraryServerTest.java
@@ -37,7 +37,7 @@ public class LibraryServerTest {
                 .interceptor(authenticator) //
                 .httpService(httpService) //
                 .build();
-        UsersPage page = client.getUsers(Optional.empty(), Optional.empty());
+        UsersPage page = client.getUsers(Optional.empty(), Optional.empty()).get();
         assertEquals(20, page.users().value().size());
         assertEquals("User19", page.users().value().get(18).firstName());
     }

--- a/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/paths/PathsServerTest.java
+++ b/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/paths/PathsServerTest.java
@@ -137,7 +137,7 @@ public class PathsServerTest {
     @ParameterizedTest
     @MethodSource("httpServices")
     public void testOctetStreamWithClient(HttpService httpService) {
-        assertEquals("hello there", new String(client(httpService).bytesGet(), StandardCharsets.UTF_8));
+        assertEquals("hello there", new String(client(httpService).bytesGet().get(), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -148,7 +148,7 @@ public class PathsServerTest {
     @ParameterizedTest
     @MethodSource("httpServices")
     public void testClientNoArgs(HttpService httpService) throws ServiceException {
-        HttpResponse r = client(httpService).itemGetFullResponse();
+        HttpResponse r = client(httpService).itemGet().fullResponse();
         assertEquals(200, r.statusCode());
         assertTrue(r.data().isPresent());
         Response2 a = (Response2) r.data().get();
@@ -158,7 +158,7 @@ public class PathsServerTest {
     @ParameterizedTest
     @MethodSource("httpServices")
     public void testClientFullResponseMultiTypeWithAcceptHeaderJson(HttpService httpService) {
-        HttpResponse r = client(httpService).responseMultiTypeGetFullResponse("application/json", "jason");
+        HttpResponse r = client(httpService).responseMultiTypeGet("application/json", "jason").fullResponse();
         assertEquals(200, r.statusCode());
     }
 
@@ -175,7 +175,7 @@ public class PathsServerTest {
     @ParameterizedTest
     @MethodSource("httpServices")
     public void testClientResponseMultiTypeWithAcceptHeaderOctetStream(HttpService httpService) {
-        HttpResponse r = client(httpService).responseMultiTypeGetFullResponse("application/octet-stream", "jason");
+        HttpResponse r = client(httpService).responseMultiTypeGet("application/octet-stream", "jason").fullResponse();
         assertEquals(200, r.statusCode());
         assertEquals("hello there", new String((byte[]) r.data().get(), StandardCharsets.UTF_8));
         assertTrue(r.headers().contains("content-type", "application/octet-stream"));
@@ -184,7 +184,7 @@ public class PathsServerTest {
     @ParameterizedTest
     @MethodSource("httpServices")
     public void testDefaultErrorReturned(HttpService httpService) {
-        HttpResponse r = client(httpService).defaultErrorGetFullResponse();
+        HttpResponse r = client(httpService).defaultErrorGet().fullResponse();
         org.davidmoten.oa3.codegen.test.paths.schema.Error e = r.dataUnwrapped();
         assertEquals("not found eh", e.errorMessage().orElse(""));
     }
@@ -192,13 +192,13 @@ public class PathsServerTest {
     @ParameterizedTest
     @MethodSource("httpServices")
     public void testSimpleStringJsonResponse(HttpService httpService) {
-        assertEquals("hello", client(httpService).jsonStringGet().value());
+        assertEquals("hello", client(httpService).jsonStringGet().get().value());
     }
 
     @ParameterizedTest
     @MethodSource("httpServices")
     public void testWildcardStatusCode(HttpService httpService) {
-        assertEquals("hi there", client(httpService).wildcardStatusCodeGetFullResponse().<Response4>dataUnwrapped().value());
+        assertEquals("hi there", client(httpService).wildcardStatusCodeGet().fullResponse().<Response4>dataUnwrapped().value());
     }    
     
     @ParameterizedTest
@@ -212,7 +212,7 @@ public class PathsServerTest {
                                 .contentType(ContentType.APPLICATION_PDF) //
                                 .value(new byte[] { 1, 2, 3 }) //
                                 .build()) //
-                        .build());
+                        .build()).get();
         assertTrue(o instanceof ObjectNode);
         assertTrue(((ObjectNode) o).isEmpty());
     }
@@ -222,7 +222,7 @@ public class PathsServerTest {
     public void testUrlEncodedFormData(HttpService httpService) {
         SubmitPostRequestApplicationXWwwFormUrlencoded request = //
                 SubmitPostRequestApplicationXWwwFormUrlencoded.name("Fred").count(23).build();
-        Object o = client(httpService).submitPost(request);
+        Object o = client(httpService).submitPost(request).get();
         assertTrue(o instanceof ObjectNode);
         assertTrue(((ObjectNode) o).isEmpty());
     }

--- a/src/docs/Bike.java
+++ b/src/docs/Bike.java
@@ -25,7 +25,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 @JsonInclude(Include.NON_NULL)
 @JsonAutoDetect(fieldVisibility = Visibility.ANY, creatorVisibility = Visibility.ANY, setterVisibility = Visibility.ANY)
 @Generated(value = "com.github.davidmoten:openapi-codegen-runtime:0.1.9-SNAPSHOT")
-public final class Bike implements Vehicle, HasWheels {
+public final class Bike implements HasWheels, Vehicle {
 
     @JsonProperty("vehicleType")
     private final String vehicleType;

--- a/src/docs/Car.java
+++ b/src/docs/Car.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 @JsonInclude(Include.NON_NULL)
 @JsonAutoDetect(fieldVisibility = Visibility.ANY, creatorVisibility = Visibility.ANY, setterVisibility = Visibility.ANY)
 @Generated(value = "com.github.davidmoten:openapi-codegen-runtime:0.1.9-SNAPSHOT")
-public final class Car implements Vehicle, HasWheels {
+public final class Car implements HasWheels, Vehicle {
 
     @JsonProperty("vehicleType")
     private final String vehicleType;

--- a/src/docs/Client.java
+++ b/src/docs/Client.java
@@ -43,6 +43,16 @@ public class Client {
         return new ClientBuilder<>(b -> new Client(b.serializer(), b.interceptors(), b.basePath(), b.httpService()), Globals.config(), basePath);
     }
 
+    private Builder http(HttpMethod method, String path) {
+        return Http
+                .method(method)
+                .basePath(this.basePath)
+                .path(path)
+                .serializer(this.serializer)
+                .interceptors(this.interceptors)
+                .httpService(this.httpService);
+    }
+
     /**
      * <p>List users page by page, filtered by search if present
      * 
@@ -57,13 +67,7 @@ public class Client {
     public RequestBuilder<UsersPage> getUsers(
             Optional<String> search, 
             Optional<String> continuationToken) {
-        return Http
-                .method(HttpMethod.GET)
-                .basePath(this.basePath)
-                .path("/user")
-                .serializer(this.serializer)
-                .interceptors(this.interceptors)
-                .httpService(this.httpService)
+        return http(HttpMethod.GET, "/user")
                 .acceptApplicationJson()
                 .queryParam("search", search)
                 .queryParam("continuationToken", continuationToken)
@@ -82,13 +86,7 @@ public class Client {
      */
     public RequestBuilder<Void> createUser(
             User requestBody) {
-        return Http
-                .method(HttpMethod.POST)
-                .basePath(this.basePath)
-                .path("/user")
-                .serializer(this.serializer)
-                .interceptors(this.interceptors)
-                .httpService(this.httpService)
+        return http(HttpMethod.POST, "/user")
                 .body(requestBody)
                 .contentTypeApplicationJson()
                 .<Void>requestBuilder();
@@ -105,13 +103,7 @@ public class Client {
      */
     public RequestBuilder<User> getUser(
             String id) {
-        return Http
-                .method(HttpMethod.GET)
-                .basePath(this.basePath)
-                .path("/user/{id}")
-                .serializer(this.serializer)
-                .interceptors(this.interceptors)
-                .httpService(this.httpService)
+        return http(HttpMethod.GET, "/user/{id}")
                 .acceptApplicationJson()
                 .pathParam("id", id)
                 .responseAs(User.class)
@@ -132,13 +124,7 @@ public class Client {
     public RequestBuilder<Void> updateUser(
             String id, 
             User requestBody) {
-        return Http
-                .method(HttpMethod.PUT)
-                .basePath(this.basePath)
-                .path("/user/{id}")
-                .serializer(this.serializer)
-                .interceptors(this.interceptors)
-                .httpService(this.httpService)
+        return http(HttpMethod.PUT, "/user/{id}")
                 .pathParam("id", id)
                 .body(requestBody)
                 .contentTypeApplicationJson()
@@ -154,13 +140,7 @@ public class Client {
      */
     public RequestBuilder<Void> deleteUser(
             String id) {
-        return Http
-                .method(HttpMethod.DELETE)
-                .basePath(this.basePath)
-                .path("/user/{id}")
-                .serializer(this.serializer)
-                .interceptors(this.interceptors)
-                .httpService(this.httpService)
+        return http(HttpMethod.DELETE, "/user/{id}")
                 .pathParam("id", id)
                 .<Void>requestBuilder();
     }
@@ -176,13 +156,7 @@ public class Client {
      */
     public RequestBuilder<Item> getItem(
             String itemId) {
-        return Http
-                .method(HttpMethod.GET)
-                .basePath(this.basePath)
-                .path("/item/{itemId}")
-                .serializer(this.serializer)
-                .interceptors(this.interceptors)
-                .httpService(this.httpService)
+        return http(HttpMethod.GET, "/item/{itemId}")
                 .acceptApplicationJson()
                 .pathParam("itemId", itemId)
                 .responseAs(Item.class)

--- a/src/docs/Client.java
+++ b/src/docs/Client.java
@@ -3,14 +3,15 @@ package org.davidmoten.oa3.codegen.test.library.client;
 import jakarta.annotation.Generated;
 
 import java.lang.String;
+import java.lang.Void;
 import java.util.List;
 import java.util.Optional;
 
 import org.davidmoten.oa3.codegen.client.runtime.ClientBuilder;
 import org.davidmoten.oa3.codegen.http.Http;
 import org.davidmoten.oa3.codegen.http.Http.Builder;
+import org.davidmoten.oa3.codegen.http.Http.RequestBuilder;
 import org.davidmoten.oa3.codegen.http.HttpMethod;
-import org.davidmoten.oa3.codegen.http.HttpResponse;
 import org.davidmoten.oa3.codegen.http.Interceptor;
 import org.davidmoten.oa3.codegen.http.Serializer;
 import org.davidmoten.oa3.codegen.http.service.HttpService;
@@ -51,31 +52,9 @@ public class Client {
      *            <p>search
      * @param continuationToken
      *            <p>continuationToken
-     * @return primary response with status code 200
-     * @throws org.davidmoten.oa3.codegen.http.NotPrimaryResponseException
-     *              if an unexpected HTTP status code or Content-Type is returned
+     * @return call builder
      */
-    public UsersPage getUsers(
-            Optional<String> search, 
-            Optional<String> continuationToken) {
-        return getUsersFullResponse(search, continuationToken)
-                .assertStatusCodeMatches("200")
-                .assertContentTypeMatches("application/json")
-                .dataUnwrapped();
-    }
-
-    /**
-     * <p>List users page by page, filtered by search if present
-     * 
-     * <p>[status=200, application/json] --&gt; {@link UsersPage}
-     * 
-     * @param search
-     *            <p>search
-     * @param continuationToken
-     *            <p>continuationToken
-     * @return full response with status code, body and headers
-     */
-    public HttpResponse getUsersFullResponse(
+    public RequestBuilder<UsersPage> getUsers(
             Optional<String> search, 
             Optional<String> continuationToken) {
         return Http
@@ -91,7 +70,7 @@ public class Client {
                 .responseAs(UsersPage.class)
                 .whenStatusCodeMatches("200")
                 .whenContentTypeMatches("application/json")
-                .call();
+                .<UsersPage>requestBuilder("200", "application/json");
     }
 
     /**
@@ -99,9 +78,9 @@ public class Client {
      * 
      * @param requestBody
      *            <p>requestBody
-     * @return full response with status code, body and headers
+     * @return call builder
      */
-    public HttpResponse createUserFullResponse(
+    public RequestBuilder<Void> createUser(
             User requestBody) {
         return Http
                 .method(HttpMethod.POST)
@@ -112,7 +91,7 @@ public class Client {
                 .httpService(this.httpService)
                 .body(requestBody)
                 .contentTypeApplicationJson()
-                .call();
+                .<Void>requestBuilder();
     }
 
     /**
@@ -122,28 +101,9 @@ public class Client {
      * 
      * @param id
      *            <p>id
-     * @return primary response with status code 200
-     * @throws org.davidmoten.oa3.codegen.http.NotPrimaryResponseException
-     *              if an unexpected HTTP status code or Content-Type is returned
+     * @return call builder
      */
-    public User getUser(
-            String id) {
-        return getUserFullResponse(id)
-                .assertStatusCodeMatches("200")
-                .assertContentTypeMatches("application/json")
-                .dataUnwrapped();
-    }
-
-    /**
-     * <p>Gets user details
-     * 
-     * <p>[status=200, application/json] --&gt; {@link User}
-     * 
-     * @param id
-     *            <p>id
-     * @return full response with status code, body and headers
-     */
-    public HttpResponse getUserFullResponse(
+    public RequestBuilder<User> getUser(
             String id) {
         return Http
                 .method(HttpMethod.GET)
@@ -157,7 +117,7 @@ public class Client {
                 .responseAs(User.class)
                 .whenStatusCodeMatches("200")
                 .whenContentTypeMatches("application/json")
-                .call();
+                .<User>requestBuilder("200", "application/json");
     }
 
     /**
@@ -167,9 +127,9 @@ public class Client {
      *            <p>requestBody
      * @param id
      *            <p>id
-     * @return full response with status code, body and headers
+     * @return call builder
      */
-    public HttpResponse updateUserFullResponse(
+    public RequestBuilder<Void> updateUser(
             String id, 
             User requestBody) {
         return Http
@@ -182,7 +142,7 @@ public class Client {
                 .pathParam("id", id)
                 .body(requestBody)
                 .contentTypeApplicationJson()
-                .call();
+                .<Void>requestBuilder();
     }
 
     /**
@@ -190,9 +150,9 @@ public class Client {
      * 
      * @param id
      *            <p>id
-     * @return full response with status code, body and headers
+     * @return call builder
      */
-    public HttpResponse deleteUserFullResponse(
+    public RequestBuilder<Void> deleteUser(
             String id) {
         return Http
                 .method(HttpMethod.DELETE)
@@ -202,7 +162,7 @@ public class Client {
                 .interceptors(this.interceptors)
                 .httpService(this.httpService)
                 .pathParam("id", id)
-                .call();
+                .<Void>requestBuilder();
     }
 
     /**
@@ -212,28 +172,9 @@ public class Client {
      * 
      * @param itemId
      *            <p>itemId
-     * @return primary response with status code 200
-     * @throws org.davidmoten.oa3.codegen.http.NotPrimaryResponseException
-     *              if an unexpected HTTP status code or Content-Type is returned
+     * @return call builder
      */
-    public Item getItem(
-            String itemId) {
-        return getItemFullResponse(itemId)
-                .assertStatusCodeMatches("200")
-                .assertContentTypeMatches("application/json")
-                .dataUnwrapped();
-    }
-
-    /**
-     * <p>Gets item details
-     * 
-     * <p>[status=200, application/json] --&gt; {@link Item}
-     * 
-     * @param itemId
-     *            <p>itemId
-     * @return full response with status code, body and headers
-     */
-    public HttpResponse getItemFullResponse(
+    public RequestBuilder<Item> getItem(
             String itemId) {
         return Http
                 .method(HttpMethod.GET)
@@ -247,7 +188,7 @@ public class Client {
                 .responseAs(Item.class)
                 .whenStatusCodeMatches("200")
                 .whenContentTypeMatches("application/json")
-                .call();
+                .<Item>requestBuilder("200", "application/json");
     }
 
     public Builder _custom(HttpMethod method, String path) {


### PR DESCRIPTION
Breaking change which allows every api call to
* have custom timeouts
* have extra headers (especially useful for Accept headers to indicate response preference)

This PR
* halves the number of generated client methods (fullResponse now available through the RequestBuilder)
* reduces the size of every generated client method by 6 lines via reuse of a generated private method
