### PR TITLE
avoid server enum conflicts

### DIFF
--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/ClientCodeWriter.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/writer/ClientCodeWriter.java
@@ -85,9 +85,15 @@ public class ClientCodeWriter {
             out.println();
             out.line("public enum Server {");
             out.println();
+            Set<String> enumNames = new HashSet<>();
             for (int i = 0; i < servers.size(); i++) {
                 Server server = servers.get(i);
-                String name = Names.enumNameToEnumConstant(server.description.orElse("server" + (i+1)));
+                String fallbackName = "server" + (i + 1);
+                String name = Names.enumNameToEnumConstant(server.description.orElse(fallbackName));
+                if (enumNames.contains(name)) {
+                    name = Names.enumNameToEnumConstant(fallbackName);
+                }
+                enumNames.add(name);
                 final String delimiter = i == servers.size() - 1 ? ";": ",";
                 out.line("%s(\"%s\")%s", name, server.url, delimiter);
             }

--- a/openapi-codegen-generator/src/main/spotbugs/filter.xml
+++ b/openapi-codegen-generator/src/main/spotbugs/filter.xml
@@ -14,6 +14,7 @@
   <Bug pattern="SE_NO_SERIALVERSIONID"/>
   <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD"/>
   <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+  <Bug pattern="NM_CLASS_NOT_EXCEPTION"/>
   <And>
     <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
     <Class name="org.davidmoten.oa3.codegen.generator.CodeWriter"/>

--- a/openapi-codegen-maven-plugin-test/src/main/openapi/paths.yml
+++ b/openapi-codegen-maven-plugin-test/src/main/openapi/paths.yml
@@ -5,7 +5,84 @@ info:
   version: 0.1
 
 servers:
-  - url: https://myservice.com/v1
+  - url: 'http://catalog.marketplace.{region}.amazonaws.com'
+    variables:
+      region:
+        description: The AWS region
+        enum:
+          - us-east-1
+          - us-east-2
+          - us-west-1
+          - us-west-2
+          - us-gov-west-1
+          - us-gov-east-1
+          - ca-central-1
+          - eu-north-1
+          - eu-west-1
+          - eu-west-2
+          - eu-west-3
+          - eu-central-1
+          - eu-south-1
+          - af-south-1
+          - ap-northeast-1
+          - ap-northeast-2
+          - ap-northeast-3
+          - ap-southeast-1
+          - ap-southeast-2
+          - ap-east-1
+          - ap-south-1
+          - sa-east-1
+          - me-south-1
+        default: us-east-1
+    description: The AWS Marketplace Catalog multi-region endpoint
+  - url: 'https://catalog.marketplace.{region}.amazonaws.com'
+    variables:
+      region:
+        description: The AWS region
+        enum:
+          - us-east-1
+          - us-east-2
+          - us-west-1
+          - us-west-2
+          - us-gov-west-1
+          - us-gov-east-1
+          - ca-central-1
+          - eu-north-1
+          - eu-west-1
+          - eu-west-2
+          - eu-west-3
+          - eu-central-1
+          - eu-south-1
+          - af-south-1
+          - ap-northeast-1
+          - ap-northeast-2
+          - ap-northeast-3
+          - ap-southeast-1
+          - ap-southeast-2
+          - ap-east-1
+          - ap-south-1
+          - sa-east-1
+          - me-south-1
+        default: us-east-1
+    description: The AWS Marketplace Catalog multi-region endpoint
+  - url: 'http://catalog.marketplace.{region}.amazonaws.com.cn'
+    variables:
+      region:
+        description: The AWS region
+        enum:
+          - cn-north-1
+          - cn-northwest-1
+        default: cn-north-1
+    description: The AWS Marketplace Catalog endpoint for China (Beijing) and China (Ningxia)
+  - url: 'https://catalog.marketplace.{region}.amazonaws.com.cn'
+    variables:
+      region:
+        description: The AWS region
+        enum:
+          - cn-north-1
+          - cn-northwest-1
+        default: cn-north-1
+    description: The AWS Marketplace Catalog endpoint for China (Beijing) and China (Ningxia)
 
 paths:
 


### PR DESCRIPTION
This PR ensures that generated enum names for server entries are distinct (not perfect, but close enough for the moment).