### PR TITLE
fix polymorphic getters in allOf

### DIFF
--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/Names.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/Names.java
@@ -162,7 +162,7 @@ public final class Names {
     }
 
     public static String simpleClassName(String fullClassName) {
-        return stripGenerics(getLastItemInDotDelimitedString(fullClassName));
+        return getLastItemInDotDelimitedString(stripGenerics(fullClassName));
     }
 
     private static String stripGenerics(String name) {


### PR DESCRIPTION
Re #181, this PR fixes compilation of 
```
codegen ./APIs/amazonaws.com/apigateway/2015-07-09/openapi.yaml
codegen ./APIs/amazonaws.com/appflow/2020-08-23/openapi.yaml
codegen ./APIs/amazonaws.com/appintegrations/2020-07-29/openapi.yaml
codegen ./APIs/amazonaws.com/cloudfront/2016-11-25/openapi.yaml
codegen ./APIs/amazonaws.com/cloudfront/2017-03-25/openapi.yaml
codegen ./APIs/amazonaws.com/cloudfront/2017-10-30/openapi.yaml
codegen ./APIs/amazonaws.com/cloudfront/2018-06-18/openapi.yaml
codegen ./APIs/amazonaws.com/codedeploy/2014-10-06/openapi.yaml
codegen ./APIs/amazonaws.com/connect/2017-08-08/openapi.yaml
codegen ./APIs/amazonaws.com/customer-profiles/2020-08-15/openapi.yaml
codegen ./APIs/amazonaws.com/s3/2006-03-01/openapi.yaml
codegen ./APIs/amazonaws.com/verifiedpermissions/2021-12-01/openapi.yaml
codegen ./APIs/amazonaws.com/es/2015-01-01/openapi.yaml
```
