### PR TITLE
ignore provided properties on array type

### DIFF
--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/Apis.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/Apis.java
@@ -239,7 +239,9 @@ class Apis {
         } else if (schema.getNot() != null) {
             visitSchemas(category, schemaPath.add(new SchemaWithName("not", schema.getNot())), Maps.empty(), visitor);
         }
-        if (schema.getProperties() != null) {
+        if (schema.getProperties() != null && !(schema instanceof ArraySchema)) {
+            // note that doesn't make sense that an ArraySchema has properties but if provided 
+            // in openapi definition the swagger-parser doesn't ignore them unfortunately
             schema.getProperties().entrySet().forEach(
                     x -> {
                         final Schema<?> sch;


### PR DESCRIPTION
This PR fixes generation from a schema declaration like below by ignoring properties on array types.

```yaml
    CategoriesDTO:
      items:
        format: int64
        type: integer
      properties:
        empty:
          type: boolean
      type: array
```
