### PR TITLE
ensure java enum used for enum parameters #273

### DIFF
--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/Apis.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/Apis.java
@@ -192,7 +192,7 @@ class Apis {
         if (parameter != null) {
             parameter = resolveRefs(api, parameter);
             if (parameter.getSchema() != null && (!Util.isPrimitive(parameter.getSchema()) || Util.isEnum(parameter.getSchema()))) {
-                visitSchemas(category, list.add("Parameter").add(parameter.getName()), parameter.getSchema(), Maps.empty(), visitor);
+                visitSchemas(category, list, parameter.getSchema(), Maps.empty(), visitor);
             }
             visitSchemas(category, list.add("Parameter").add(parameter.getName()), parameter.getContent(), visitor);
         }

--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/Apis.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/Apis.java
@@ -191,7 +191,7 @@ class Apis {
             Visitor visitor, OpenAPI api) {
         if (parameter != null) {
             parameter = resolveRefs(api, parameter);
-            if (parameter.getSchema() != null && !Util.isPrimitive(parameter.getSchema())) {
+            if (parameter.getSchema() != null && (!Util.isPrimitive(parameter.getSchema()) || Util.isEnum(parameter.getSchema()))) {
                 visitSchemas(category, list.add("Parameter").add(parameter.getName()), parameter.getSchema(), Maps.empty(), visitor);
             }
             visitSchemas(category, list.add("Parameter").add(parameter.getName()), parameter.getContent(), visitor);

--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/ClientServerGenerator.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/ClientServerGenerator.java
@@ -129,7 +129,7 @@ public class ClientServerGenerator {
                         }
                         parameterNames.add(parameterName);
                         final Param param;
-                        if (Util.isPrimitive(s)) {
+                        if (Util.isPrimitive(s) && !Util.isEnum(s)) {
                             // handle simple schemas
                             Class<?> c = Util.toClass(Util.getTypeOrThrow(s), s.getFormat(), s.getExtensions(),
                                     names.mapIntegerToBigInteger(), names.mapNumberToBigDecimal());

--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/Generator.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/Generator.java
@@ -105,7 +105,7 @@ public class Generator {
         public boolean topLevel = false;
         public boolean hasProperties = false;
         public PolymorphicType polymorphicType;
-        public Optional<Cls> owner = Optional.empty(); // the owning heirarchy, we cannot name our class any one of
+        public Optional<Cls> owner = Optional.empty(); // the owning hierarchy, we cannot name our class any one of
         // these classes (disallowed by java)
         public Optional<String> name = Optional.empty();
         public Optional<Schema<?>> schema = Optional.empty();
@@ -119,7 +119,7 @@ public class Generator {
         private Set<String> fieldNames = new HashSet<>();
 
         public String nextFieldName(String name, Schema<?> schema) {
-            Optional<String> nameOverride = extensionString(schema, ExtensionKeys.NAME);
+            Optional<String> nameOverride = Util.extensionString(schema, ExtensionKeys.NAME);
             if (nameOverride.isPresent()) {
             	name = nameOverride.get();
             }
@@ -220,25 +220,11 @@ public class Generator {
         public boolean hasEncoding() {
             return schema.isPresent() //
                     && schema.get().getExtensions() != null //
-                    && Boolean.TRUE.equals(extension(schema.get(), ExtensionKeys.HAS_ENCODING).orElse(null));
+                    && Boolean.TRUE.equals(Util.extension(schema.get(), ExtensionKeys.HAS_ENCODING).orElse(null));
         }
     }
     
-    private static Optional<Object> extension(Schema<?> schema, String key) {
-    	Preconditions.checkNotNull(key);
-    	Map<String, Object> map = schema.getExtensions();
-    	if (map == null) {
-    		return Optional.empty();
-    	} else {
-    		return Optional.ofNullable(map.get(key));
-    	}
-    }
     
-    @SuppressWarnings("unchecked")
-	public static Optional<String> extensionString(Schema<?> schema, String key) {
-    	return (Optional<String>) (Optional<?>) extension(schema, key);
-    }
-
     public static class EnumMember {
         public final String name;
         public final Object parameter;

--- a/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/internal/Util.java
+++ b/openapi-codegen-generator/src/main/java/org/davidmoten/oa3/codegen/generator/internal/Util.java
@@ -193,4 +193,18 @@ public final class Util {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    public static Optional<String> extensionString(Schema<?> schema, String key) {
+        return (Optional<String>) (Optional<?>) extension(schema, key);
+    }
+    
+    public static Optional<Object> extension(Schema<?> schema, String key) {
+        Preconditions.checkNotNull(key);
+        Map<String, Object> map = schema.getExtensions();
+        if (map == null) {
+            return Optional.empty();
+        } else {
+            return Optional.ofNullable(map.get(key));
+        }
+    }
 }

--- a/openapi-codegen-maven-plugin-test/src/main/openapi/paths.yml
+++ b/openapi-codegen-maven-plugin-test/src/main/openapi/paths.yml
@@ -406,6 +406,15 @@ paths:
             type: integer
             format: int32
             default: 10
+        - in: query
+          name: fourth
+          schema:
+            type: string
+            enum: [one, other]
+        - in: query
+          name: fifth
+          schema:
+            $ref: '#/components/schemas/Fifth'
       responses:
         '203':    
           description: ok response
@@ -671,3 +680,8 @@ components:
         name:
           type: string
       required: [document]
+
+    Fifth:
+      type: string
+      enum: [fifth, quinto]
+      

--- a/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/paths/PathsService.java
+++ b/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/paths/PathsService.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.davidmoten.oa3.codegen.spring.runtime.ServiceException;
-import org.davidmoten.oa3.codegen.test.paths.path.QueryObjectGetIdParameterId;
+import org.davidmoten.oa3.codegen.test.paths.path.QueryObjectGetId;
 import org.davidmoten.oa3.codegen.test.paths.response.Response4;
 import org.davidmoten.oa3.codegen.test.paths.schema.Error;
 import org.davidmoten.oa3.codegen.test.paths.schema.Name;
@@ -42,7 +42,7 @@ public class PathsService implements Service {
     }
 
     @Override
-    public void queryObjectGet(QueryObjectGetIdParameterId id) throws ServiceException {
+    public void queryObjectGet(QueryObjectGetId id) throws ServiceException {
         System.out.println(id.first() + ", " + id.second().get());
     }
 

--- a/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/paths/PathsTest.java
+++ b/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/paths/PathsTest.java
@@ -94,7 +94,7 @@ public class PathsTest {
                 Optional.of(ParamsGetFourthParameterFourth.OTHER), 
                 Optional.of(Fifth.QUINTO));
         hasSignature(Service.class, "paramsGet", String.class, OffsetDateTime.class, Optional.class, int.class,
-                Optional.class);
+                Optional.class, Optional.class);
     }
 
     @Test

--- a/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/paths/PathsTest.java
+++ b/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/paths/PathsTest.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import org.davidmoten.oa3.codegen.spring.runtime.ServiceException;
-import org.davidmoten.oa3.codegen.test.paths.path.ParamsGetFourthParameterFourth;
+import org.davidmoten.oa3.codegen.test.paths.path.ParamsGetFourth;
 import org.davidmoten.oa3.codegen.test.paths.response.Response4;
 import org.davidmoten.oa3.codegen.test.paths.schema.Fifth;
 import org.davidmoten.oa3.codegen.test.paths.schema.RequestBody1;
@@ -91,7 +91,7 @@ public class PathsTest {
     @Test
     public void testParams() throws ServiceException {
         Response2 response = service.paramsGet("123abc", OffsetDateTime.now(), Optional.of(123L), 45,
-                Optional.of(ParamsGetFourthParameterFourth.OTHER), 
+                Optional.of(ParamsGetFourth.OTHER), 
                 Optional.of(Fifth.QUINTO));
         hasSignature(Service.class, "paramsGet", String.class, OffsetDateTime.class, Optional.class, int.class,
                 Optional.class, Optional.class);
@@ -101,13 +101,13 @@ public class PathsTest {
     public void testParamsResponseStatusCode() throws ServiceException {
         Service svc = new Service() {
             @Override
-            public Response2 paramsGet(String id, OffsetDateTime first, Optional<Long> second, int third, Optional<ParamsGetFourthParameterFourth> fourth, Optional<Fifth> fifth)
+            public Response2 paramsGet(String id, OffsetDateTime first, Optional<Long> second, int third, Optional<ParamsGetFourth> fourth, Optional<Fifth> fifth)
                     throws ServiceException {
                 return new Response2("token123");
             }
         };
         ServiceController c = new ServiceController(svc);
-        ResponseEntity<?> r = c.paramsGet("123abc", OffsetDateTime.now(), Optional.of(123L), 45,Optional.of(ParamsGetFourthParameterFourth.OTHER), Optional.of(Fifth.QUINTO));
+        ResponseEntity<?> r = c.paramsGet("123abc", OffsetDateTime.now(), Optional.of(123L), 45,Optional.of(ParamsGetFourth.OTHER), Optional.of(Fifth.QUINTO));
         assertEquals(203, r.getStatusCodeValue());
     }
 

--- a/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/paths/PathsTest.java
+++ b/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/paths/PathsTest.java
@@ -12,7 +12,9 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import org.davidmoten.oa3.codegen.spring.runtime.ServiceException;
+import org.davidmoten.oa3.codegen.test.paths.path.ParamsGetFourthParameterFourth;
 import org.davidmoten.oa3.codegen.test.paths.response.Response4;
+import org.davidmoten.oa3.codegen.test.paths.schema.Fifth;
 import org.davidmoten.oa3.codegen.test.paths.schema.RequestBody1;
 import org.davidmoten.oa3.codegen.test.paths.schema.RequestBody2;
 import org.davidmoten.oa3.codegen.test.paths.schema.Response1;
@@ -88,21 +90,24 @@ public class PathsTest {
 
     @Test
     public void testParams() throws ServiceException {
-        Response2 response = service.paramsGet("123abc", OffsetDateTime.now(), Optional.of(123L), 45);
-        hasSignature(Service.class, "paramsGet", String.class, OffsetDateTime.class, Optional.class, int.class);
+        Response2 response = service.paramsGet("123abc", OffsetDateTime.now(), Optional.of(123L), 45,
+                Optional.of(ParamsGetFourthParameterFourth.OTHER), 
+                Optional.of(Fifth.QUINTO));
+        hasSignature(Service.class, "paramsGet", String.class, OffsetDateTime.class, Optional.class, int.class,
+                Optional.class);
     }
 
     @Test
     public void testParamsResponseStatusCode() throws ServiceException {
         Service svc = new Service() {
             @Override
-            public Response2 paramsGet(String id, OffsetDateTime first, Optional<Long> second, int third)
+            public Response2 paramsGet(String id, OffsetDateTime first, Optional<Long> second, int third, Optional<ParamsGetFourthParameterFourth> fourth, Optional<Fifth> fifth)
                     throws ServiceException {
                 return new Response2("token123");
             }
         };
         ServiceController c = new ServiceController(svc);
-        ResponseEntity<?> r = c.paramsGet("123abc", OffsetDateTime.now(), Optional.of(123L), 45);
+        ResponseEntity<?> r = c.paramsGet("123abc", OffsetDateTime.now(), Optional.of(123L), 45,Optional.of(ParamsGetFourthParameterFourth.OTHER), Optional.of(Fifth.QUINTO));
         assertEquals(203, r.getStatusCodeValue());
     }
 


### PR DESCRIPTION
* Fix for #273
* [Breaking change] Also fixes overly verbose auto-generated class names for enum or complex anonymous parameter types so that:

```yaml
paths:
   /params:
      get:
      parameters:
        - name: first
          in: query
          type: string
          enum: [thing, other]
```
generates a type for the `first` parameter called `ParamsGetFirst` instead of `ParamsGetFirstParameterFirst`