### PR TITLE
support repeated inline primitive types in oneOf (does validation)

### DIFF
--- a/openapi-codegen-maven-plugin-test/src/main/openapi/main.yml
+++ b/openapi-codegen-maven-plugin-test/src/main/openapi/main.yml
@@ -1165,7 +1165,14 @@ components:
           oneOf:
           - type: string
           - type: integer
-            format: int32          
+            format: int32  
+            
+    OfStrings:
+        oneOf:
+        - type: string
+          pattern: 'a.*'
+        - type: string
+          pattern: 'b.*'        
 
     Simple:
       type: string

--- a/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/main/SchemasTest.java
+++ b/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/main/SchemasTest.java
@@ -251,7 +251,7 @@ public class SchemasTest {
         assertEquals(123, a.value().get(1).value());
         assertEquals(json, m.writeValueAsString(a));
         assertEquals(json, m.writeValueAsString(
-                new ArrayOfOneOf(Arrays.asList(new ArrayOfOneOfItem(true), new ArrayOfOneOfItem(123)))));
+                new ArrayOfOneOf(Arrays.asList(ArrayOfOneOfItem.of(true), ArrayOfOneOfItem.of(123)))));
     }
 
     @Test
@@ -262,7 +262,7 @@ public class SchemasTest {
         assertEquals(123, a.value().get(1).value());
         assertEquals(json, m.writeValueAsString(a));
         assertEquals(json, m.writeValueAsString(new ArrayOfOneOfString(
-                Arrays.asList(new ArrayOfOneOfStringItem("hello"), new ArrayOfOneOfStringItem(123)))));
+                Arrays.asList(ArrayOfOneOfStringItem.of("hello"), ArrayOfOneOfStringItem.of(123)))));
     }
 
     @Test
@@ -1272,5 +1272,12 @@ public class SchemasTest {
     private static void noPublicConstructors(Class<?> c) {
         assertEquals(0, c.getConstructors().length);
     }
-
+    
+    @Test
+    public void testOneOfTwoStringTypesWithConstraints() {
+        assertEquals("a", OfStrings.of("a").value());
+        assertEquals("b", OfStrings.of2("b").value());
+        assertThrows(IllegalArgumentException.class, () -> OfStrings.of("b"));
+        assertThrows(IllegalArgumentException.class, () -> OfStrings.of2("a"));
+    }
 }


### PR DESCRIPTION
Adds support for this scenario:

```yaml
    OfStrings:
        oneOf:
        - type: string
          pattern: 'a.*'
        - type: string
          pattern: 'b.*' 
```
Previously did not compile (with repeated constructors and `of` factory methods and no constraint validation). Support was already in existence for oneOf members that were not inline (named components).