### PR TITLE
avoid deprecated `ResponseEntity.getStatusCodeValue` method for SpringBoot 3 compat

### DIFF
--- a/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/paths/PathsTest.java
+++ b/openapi-codegen-maven-plugin-test/src/test/java/org/davidmoten/oa3/codegen/test/paths/PathsTest.java
@@ -108,7 +108,7 @@ public class PathsTest {
         };
         ServiceController c = new ServiceController(svc);
         ResponseEntity<?> r = c.paramsGet("123abc", OffsetDateTime.now(), Optional.of(123L), 45,Optional.of(ParamsGetFourth.OTHER), Optional.of(Fifth.QUINTO));
-        assertEquals(203, r.getStatusCodeValue());
+        assertEquals(203, r.getStatusCode().value());
     }
 
     @Test

--- a/openapi-codegen-spring-runtime/src/main/java/org/davidmoten/oa3/codegen/spring/runtime/ServiceException.java
+++ b/openapi-codegen-spring-runtime/src/main/java/org/davidmoten/oa3/codegen/spring/runtime/ServiceException.java
@@ -28,7 +28,7 @@ public final class ServiceException extends Exception {
     }
 
     public ServiceException(ResponseEntity<?> response) {
-        this(response.getStatusCodeValue(), response.getStatusCode().toString(), Optional.of(response));
+        this(response.getStatusCode().value(), response.getStatusCode().toString(), Optional.of(response));
     }
 
     public int statusCode() {


### PR DESCRIPTION
As raised in #315